### PR TITLE
fix: completion is complete

### DIFF
--- a/lib/LanguageServerCompletion/Handler/CompletionHandler.php
+++ b/lib/LanguageServerCompletion/Handler/CompletionHandler.php
@@ -95,7 +95,7 @@ class CompletionHandler implements Handler, CanRegisterCapabilities
             );
 
             $completionList = new CompletionList();
-            $completionList->isIncomplete = true;
+            $completionList->isIncomplete = false;
 
             foreach ($suggestions as $suggestion) {
                 $name = $this->suggestionNameFormatter->format($suggestion);
@@ -128,10 +128,13 @@ class CompletionHandler implements Handler, CanRegisterCapabilities
                 try {
                     $token->throwIfRequested();
                 } catch (CancelledException $cancellation) {
+                    $completionList->isIncomplete = true;
                     break;
                 }
                 yield new Delayed(0);
             }
+
+            $completionList->isIncomplete = $completionList->isIncomplete || !$suggestions->getReturn();
 
             return $completionList;
         });


### PR DESCRIPTION
Uses https://github.com/phpactor/completion/pull/30 to fill the `CompletionList::isIncomplete` property.

Need to be merged before this:
* [x] https://github.com/phpactor/completion/pull/30
* [x] ~#7 - Because there will be conflict otherwise and I don't want to deal with them twice :)~ Cherry-pick changes to master to isolate them