### PR TITLE
Updates to accomodate event dispatcher change

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "^7.3",
         "phpactor/container": "~1.3",
-        "phpactor/language-server": "~0.3",
+        "phpactor/language-server": "~0.4",
         "phpactor/console-extension": "~0.1",
         "phpactor/logging-extension": "~0.3.3",
         "phpactor/file-path-resolver-extension": "~0.2",

--- a/tests/LanguageServer/Unit/LanguageServerExtensionTest.php
+++ b/tests/LanguageServer/Unit/LanguageServerExtensionTest.php
@@ -2,26 +2,42 @@
 
 namespace Phpactor\Extension\LanguageServer\Tests\Unit;
 
+use Phpactor\Extension\LanguageServer\LanguageServerExtension;
+use Phpactor\LanguageServer\Core\Session\WorkspaceListener;
+
 class LanguageServerExtensionTest extends LanguageServerTestCase
 {
-    public function testInitializesLanguageServer()
+    public function testInitializesLanguageServer(): void
     {
         $serverTester = $this->createTester();
         $serverTester->initialize();
     }
 
-    public function testLoadsTextDocuments()
+    public function testLoadsTextDocuments(): void
     {
         $serverTester = $this->createTester();
         $responses = $serverTester->initialize();
         $serverTester->assertSuccess($responses);
     }
 
-    public function testLoadsHandlers()
+    public function testLoadsHandlers(): void
     {
         $serverTester = $this->createTester();
         $serverTester->initialize();
         $response = $serverTester->dispatchAndWait(1, 'test', []);
         $this->assertTrue($serverTester->assertSuccess($response));
+    }
+
+    public function testDisablesWorkspaceListener(): void
+    {
+        // workspace is enabled by default
+        $container = $this->createContainer();
+        self::assertInstanceOf(WorkspaceListener::class, $container->get(WorkspaceListener::class));
+
+        // if disabled it returns NULL and will not be registered
+        $container = $this->createContainer([
+            LanguageServerExtension::PARAM_ENABLE_WORKPACE => false,
+        ]);
+        self::assertNull($container->get(WorkspaceListener::class));
     }
 }


### PR DESCRIPTION
- Event dispatcher is now belonging to the Handler not the Workspace.
- The workspace is now updated via. a listener,
- The workspace can be disabled.

(note the background for this change is to allow a document saved event to be emitted and to facilitate implementations which do not require a workspace, e.g. Phpstan)