### PR TITLE
Fix #1304 - Dynamic registration only if supported

### DIFF
--- a/lib/LanguageServer/LanguageServerExtension.php
+++ b/lib/LanguageServer/LanguageServerExtension.php
@@ -13,6 +13,7 @@ use Phpactor\Extension\LanguageServer\Listener\InvalidConfigListener;
 use Phpactor\Extension\Logger\LoggingExtension;
 use Phpactor\Extension\Console\ConsoleExtension;
 use Phpactor\Extension\LanguageServer\Command\StartCommand;
+use Phpactor\LanguageServerProtocol\ClientCapabilities;
 use Phpactor\LanguageServer\Core\CodeAction\AggregateCodeActionProvider;
 use Phpactor\LanguageServer\Core\Command\CommandDispatcher;
 use Phpactor\LanguageServer\Core\Diagnostics\AggregateDiagnosticsProvider;
@@ -186,7 +187,11 @@ class LanguageServerExtension implements Extension
         ]);
 
         $container->register(DidChangeWatchedFilesListener::class, function (Container $container) {
-            return new DidChangeWatchedFilesListener($container->get(ClientApi::class), $container->getParameter(self::PARAM_FILE_EVENT_GLOBS));
+            return new DidChangeWatchedFilesListener(
+                $container->get(ClientApi::class),
+                $container->getParameter(self::PARAM_FILE_EVENT_GLOBS),
+                $container->get(ClientCapabilities::class),
+            );
         }, [
             self::TAG_LISTENER_PROVIDER => [],
         ]);

--- a/tests/LanguageServer/Unit/LanguageServerExtensionTest.php
+++ b/tests/LanguageServer/Unit/LanguageServerExtensionTest.php
@@ -3,12 +3,14 @@
 namespace Phpactor\Extension\LanguageServer\Tests\Unit;
 
 use Phpactor\Extension\LanguageServer\LanguageServerExtension;
+use Phpactor\LanguageServerProtocol\ClientCapabilities;
 use Phpactor\LanguageServerProtocol\CodeActionRequest;
 use Phpactor\LanguageServerProtocol\InitializeParams;
 use Phpactor\LanguageServer\Core\Rpc\NotificationMessage;
 use Phpactor\LanguageServer\Core\Rpc\RequestMessage;
 use Phpactor\LanguageServer\Core\Server\Exception\ExitSession;
 use Phpactor\LanguageServer\Listener\WorkspaceListener;
+use Phpactor\LanguageServer\Test\ProtocolFactory;
 use RuntimeException;
 use function Amp\Promise\wait;
 use function Amp\delay;
@@ -151,7 +153,11 @@ class LanguageServerExtensionTest extends LanguageServerTestCase
 
     public function testEnableFileEvents(): void
     {
-        $serverTester = $this->createTester(null, [
+        $params = ProtocolFactory::initializeParams($this->workspace()->path('/'));
+        $params->capabilities = new ClientCapabilities([
+            'didChangeWatchedFiles' => ['dynamicRegistration' => true],
+        ]);
+        $serverTester = $this->createTester($params, [
             LanguageServerExtension::PARAM_FILE_EVENTS => true
         ]);
         $serverTester->initialize();


### PR DESCRIPTION
Go with https://github.com/phpactor/language-server/pull/38 and update the service definition for `DidChangeWatchedFilesListener`.