### PR TITLE
Update progress notifier & add example tests

### DIFF
--- a/lib/LanguageServer/LanguageServerSessionExtension.php
+++ b/lib/LanguageServer/LanguageServerSessionExtension.php
@@ -13,8 +13,7 @@ use Phpactor\LanguageServer\Core\Server\ResponseWatcher\DeferredResponseWatcher;
 use Phpactor\LanguageServer\Core\Server\RpcClient;
 use Phpactor\LanguageServer\Core\Server\RpcClient\JsonRpcClient;
 use Phpactor\LanguageServer\Core\Server\Transmitter\MessageTransmitter;
-use Phpactor\LanguageServer\WorkDoneProgress\ClientCapabilityDependentProgressNotifier;
-use Phpactor\LanguageServer\WorkDoneProgress\ProgressNotifier;
+use Phpactor\LanguageServer\WorkDoneProgress\ProgressNotifierFactory;
 use Phpactor\MapResolver\Resolver;
 
 class LanguageServerSessionExtension implements Extension
@@ -66,8 +65,8 @@ class LanguageServerSessionExtension implements Extension
             return new JsonRpcClient($this->transmitter, $container->get(ResponseWatcher::class));
         });
 
-        $container->register(ProgressNotifier::class, function (Container $container) {
-            return new ClientCapabilityDependentProgressNotifier(
+        $container->register(ProgressNotifierFactory::class, function (Container $container) {
+            return new ProgressNotifierFactory(
                 $container->get(ClientApi::class),
                 $container->get(ClientCapabilities::class),
             );

--- a/tests/LanguageServer/Example/TestExtension.php
+++ b/tests/LanguageServer/Example/TestExtension.php
@@ -16,7 +16,6 @@ use Phpactor\LanguageServerProtocol\TextDocumentItem;
 use Phpactor\LanguageServer\Core\CodeAction\CodeActionProvider;
 use Phpactor\LanguageServer\Core\Command\Command as CoreCommand;
 use Phpactor\LanguageServer\Core\Handler\ClosureHandler;
-use Phpactor\LanguageServer\Core\Handler\Handler;
 use Phpactor\LanguageServer\Core\Rpc\NotificationMessage;
 use Phpactor\LanguageServer\Core\Server\ClientApi;
 use Phpactor\LanguageServer\Core\Service\ServiceProvider;

--- a/tests/LanguageServer/Example/TestExtension.php
+++ b/tests/LanguageServer/Example/TestExtension.php
@@ -31,21 +31,13 @@ class TestExtension implements Extension
      */
     public function load(ContainerBuilder $container): void
     {
-        $container->register('test.handler', function (Container $container) {
-            return new class implements Handler {
-                public function methods(): array
-                {
-                    return ['test' => 'test'];
-                }
-
-                public function test()
-                {
-                    return new Success(new NotificationMessage('window/showMessage', [
-                        'type' => MessageType::INFO,
-                        'message' => 'Hallo',
-                    ]));
-                }
-            };
+        $container->register('test.handler', function (Container $container): ClosureHandler {
+            return new ClosureHandler('test', function (): Promise {
+                return new Success(new NotificationMessage('window/showMessage', [
+                    'type' => MessageType::INFO,
+                    'message' => 'Hallo',
+                ]));
+            });
         }, [ LanguageServerExtension::TAG_METHOD_HANDLER => []]);
 
         $container->register('test.progress_notifier_factory', function (Container $container): ClosureHandler {
@@ -77,7 +69,10 @@ class TestExtension implements Extension
                     return ['test'];
                 }
 
-                public function test()
+                /**
+                 * @return Promise<NotificationMessage>
+                 */
+                public function test(): Promise
                 {
                     $this->api->window()->showmessage()->info('service started');
                     return new Success(new NotificationMessage('window/showMessage', [
@@ -90,6 +85,9 @@ class TestExtension implements Extension
 
         $container->register('test.command', function (Container $container) {
             return new class implements CoreCommand {
+                /**
+                 * @return Promise<string>
+                 */
                 public function __invoke(string $text): Promise
                 {
                     return new Success($text);

--- a/tests/LanguageServer/Unit/LanguageServerExtensionTest.php
+++ b/tests/LanguageServer/Unit/LanguageServerExtensionTest.php
@@ -8,6 +8,7 @@ use Phpactor\LanguageServerProtocol\CodeActionRequest;
 use Phpactor\LanguageServerProtocol\InitializeParams;
 use Phpactor\LanguageServer\Core\Rpc\NotificationMessage;
 use Phpactor\LanguageServer\Core\Rpc\RequestMessage;
+use Phpactor\LanguageServer\Core\Rpc\ResponseMessage;
 use Phpactor\LanguageServer\Core\Server\Exception\ExitSession;
 use Phpactor\LanguageServer\Listener\WorkspaceListener;
 use Phpactor\LanguageServer\Test\ProtocolFactory;
@@ -166,5 +167,18 @@ class LanguageServerExtensionTest extends LanguageServerTestCase
         self::assertNotNull($message);
         assert($message instanceof RequestMessage);
         self::assertEquals('client/registerCapability', $message->method);
+    }
+
+    public function testProgressNotifierFactory(): void
+    {
+        $serverTester = $this->createTester(null, [
+            LanguageServerExtension::PARAM_FILE_EVENTS => true,
+        ]);
+        $serverTester->initialize();
+        $response = $serverTester->requestAndWait('test/progress_notifier_factory', []);
+
+        self::assertInstanceOf(ResponseMessage::class, $response);
+        self::assertTrue($response->result);
+        self::assertNull($response->error);
     }
 }


### PR DESCRIPTION
This integrates the changes proposed in https://github.com/phpactor/language-server/pull/39
And add the test I forgot the last time, which can be a replacement for #24 once the new interface for handling progress notification will be validated.

Next stop:
- Integrating it in the index handler in phpactor LS extension
- Integrating it in the references handler in phpactor LS extension
  - I already did a first try with the previous implementation but I don't know any client which specify the `workDoneToken` so I add to create my own implementation to test it on my machine... Does CoC handles it (it would be a pain to install it again but I can try)